### PR TITLE
support MacOS, rewrite syntax lang mapping, show quickfix window

### DIFF
--- a/plugin/dim-jump.vim
+++ b/plugin/dim-jump.vim
@@ -30,10 +30,10 @@ function s:Fileext(f) abort
   if len(fe) > 1
     return s:jn('find', getcwd(), escape(s:jn(
           \ '( -iname', join(map(copy(fe), 'string("*.".v:val)'), ' -or -iname '),
-          \ ')'), '()'), '-print0 | xargs -0')
+          \ ')'), '()'), '-print0 2>/dev/null | xargs -0')
   endif
   return s:jn('find', getcwd(), '-iname', string('*.'.fnamemodify(a:f,':e')),
-        \ '-print0 | xargs -0')
+        \ '-print0 2>/dev/null | xargs -0')
 endfunction
 
 let [s:ag, s:rg, s:grep] = ['', '', '']

--- a/plugin/dim-jump.vim
+++ b/plugin/dim-jump.vim
@@ -125,6 +125,7 @@ let s:searchprg  = {
       \ }
 
 function s:Grep(token) abort
+  execute 'ccl'
   let args = map(s:Refine(),'v:val.regex')
   if args == []
     silent! exe "norm! [\<Tab>"
@@ -146,11 +147,10 @@ function s:Grep(token) abort
   let prev = getqflist()
   let res = systemlist(grepcmd)
   if len(res)
-    silent cexpr sort(res,function('s:funcsort'))[0]."\n"
-    if getline('.')[col('.')-1] !~ '\k'
-      call search('\V\<'.escape(a:token,'\').'\>','W')
+    silent cexpr sort(res,function('s:funcsort'))
+    if (len(res) > 1)
+      execute 'copen'
     endif
-    call setqflist(prev,'r')
   endif
   let &errorformat = grepf
 endfunction

--- a/plugin/dim-jump.vim
+++ b/plugin/dim-jump.vim
@@ -64,7 +64,10 @@ function s:prog() abort
 endfunction
 
 let s:transformedFiletype = []
-let g:transformFiletypeMap = get(g:, 'transformFiletypeMap', {})
+let g:transformFiletypeMap = get(g:, 'transformFiletypeMap', {
+      \ 'javascript.jsx': 'javascript'
+      \}
+      \)
 function s:transformFiletype() abort
   if has_key(g:transformFiletypeMap,&ft)
     let s:transformedFiletype = g:transformFiletypeMap[&ft]


### PR DESCRIPTION
hi @bounceme 

Sorry, this PR contains a bunch of commits and it should be a bit hard to review. 
Let me describe what commit does what:

* `98ae292` - sometimes if `find` has no access to a directory it tries to scan, it returns warning. This warning was showing in quickfix window together with other results and in case there is only one result available the plugin was thinking there are two (because warning was counted).

* `9cb4c23`- I've noticed there is some quickfix window usage in the code but unfortunately I didn't get how it works. I've replaced the code with something I understand. Now it shows quickfix window in case there are two or more results available to jump. Please be careful here, since it's my first so big involvement in VimL.

* `4f5172d` - it seems like MacOS has different `sed` (from BSD) command and it is not working with the current set of options passed. But we can use `gsed` (GNU sed) on MacOS which works brilliant. So this commit just detect the OS and use GNU sed in case of Darwin. 

* `143c63c` and `ff7ed65` - do the same thing, I just changed my mind where to store the mapping variable. Basically for some files (like react files with JSX code) I'm getting `javascript:jsx` syntax which is not available in that rules file from dumb-jump. I've just added a map (variable) that contains mapping from one syntax to another. Like `javascript:jsx` -> 'javascript`. 

Again, please be careful when reviewing these changes since it is my first more or less significant touch to VimL. 

I use this version of script for a week now and it seems does the job correctly. 

Thanks for the huge work made from your side to port Elisp rules to json.